### PR TITLE
sarachnis rebalance

### DIFF
--- a/src/lib/minions/data/killableMonsters/index.ts
+++ b/src/lib/minions/data/killableMonsters/index.ts
@@ -221,7 +221,7 @@ const killableMonsters: KillableMonster[] = [
 		id: Monsters.Sarachnis.id,
 		name: Monsters.Sarachnis.name,
 		aliases: Monsters.Sarachnis.aliases,
-		timeToFinish: Time.Minute * 2.35,
+		timeToFinish: Time.Minute * 1.85,
 		table: Monsters.Sarachnis,
 		emoji: '<:Sraracha:608231007803670529>',
 		wildy: false,
@@ -231,6 +231,17 @@ const killableMonsters: KillableMonster[] = [
 		itemInBankBoosts: [
 			{
 				[itemID('Dragon claws')]: 5
+			},
+			{
+				[itemID('Abyssal bludgeon')]: 8,
+				[itemID("Inquisitor's mace")]: 12,
+				[itemID('Scythe of vitur')]: 15
+			},
+			{
+				[itemID("Karil's leathertop")]: 3
+			},
+			{
+				[itemID("Karil's leatherskirt")]: 2
 			}
 		],
 		levelRequirements: {


### PR DESCRIPTION
reduce base killtime by ~20%, add up to 20% in boosts with used gear ingame

before killrates were roughly 30/hr, this should put them around 44 or so, ingame killrates has ironman EHB at 56/hr, so this is still markedly lower than feasible ingame rates but is a needed rebalance for a boss that is often killed for clues, and adds additional usage for scythe (which currently isn't used many places)

### Description:

<!-- What did you change? Describe it here. -->

### Changes:

<!-- Write a comprehensive list of changes here. -->

### Other checks:

-   [ ] I have tested all my changes thoroughly.
